### PR TITLE
Firefox 42 compatibility fix

### DIFF
--- a/src/content/PageInfoOverlay.js
+++ b/src/content/PageInfoOverlay.js
@@ -47,7 +47,7 @@ livehttpheaders.overlay.getHeaderInfo = function(theDocument) {
 
 livehttpheaders.overlay.makeHeaderInfoTab = function() {
   // Only call this function once
-  var doc = ("theDocument" in window) ? theDocument : gDocument;
+  var doc = ("theDocument" in window) ? theDocument : window.opener.gBrowser.selectedBrowser.contentWindowAsCPOW.document;
   var loc = doc.location.protocol;
   const headers = livehttpheaders.overlay.getHeaderInfo(doc);
   if (headers) {
@@ -97,7 +97,7 @@ livehttpheaders.overlay.makeHeaderInfoTab = function() {
 
 livehttpheaders.overlay.saveHeaderInfoTab = function(title) {
 
-  var doc = ("theDocument" in window) ? theDocument : gDocument;
+  var doc = ("theDocument" in window) ? theDocument : window.opener.gBrowser.selectedBrowser.contentWindowAsCPOW.document;
   // First, get the URL and headers
   var txt = doc.location + "\n";
   var headers = livehttpheaders.overlay.getHeaderInfo(doc);

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -5,7 +5,7 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>{8f8fe09b-0bd3-4470-bc1b-8cad42b8203a}</em:id>
-    <em:version>0.17</em:version>
+    <em:version>0.18-alpha-ffx42</em:version>
     <em:unpack>true</em:unpack>
     <em:type>2</em:type>
    
@@ -16,7 +16,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>0.8</em:minVersion>
-        <em:maxVersion>4.0.*</em:maxVersion>
+        <em:maxVersion>42.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <!-- Flock -->


### PR DESCRIPTION
Firefox 42 compatibility fix.
Props to [debianuser](https://addons.mozilla.org/firefox/user/debian-user/) for finding the [changeset b32f21db299c](https://hg.mozilla.org/mozilla-central/rev/b32f21db299c) which introduced the incompatibility on ffx42.
